### PR TITLE
modify the dependencies on jasmine-ajax

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "jasmine-ajax"
   ],
   "dependencies": {
-    "jasmine-ajax": "git://github.com/pivotal/jasmine-ajax#477f044b4afa9b77ca834275109cbe08b362f05e"
+    "jasmine-ajax": "git://github.com/pivotal/jasmine-ajax"
   },
   "peerDependencies": {
     "karma": "~0.12.0"


### PR DESCRIPTION
HI:
    I modify the dependencies, so `npm install` will install the latest jasmine-ajax,rather than the fixed version.
