### PR TITLE
Updated jasmine-ajax version to get the latest changes

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "jasmine-ajax"
   ],
   "dependencies": {
-    "jasmine-ajax": "git://github.com/pivotal/jasmine-ajax#477f044b4afa9b77ca834275109cbe08b362f05e"
+    "jasmine-ajax": "^2.0.1"
   },
   "peerDependencies": {
     "karma": "~0.12.0"


### PR DESCRIPTION
An ajax jasmine test throws TypeError: Type error when using overrideMimeType. The latest version of jasmine-ajax has support to fix the error.

var request = new XMLHttpRequest();
request.overrideMimeType('application/json');
