### PR TITLE
the plugin needs to be listed in the plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,8 @@ Add `jasmine-ajax` to the `frameworks` key in your Karma configuration, before `
 ```js
 module.exports = function(config) {
   config.set({
-    frameworks: ['jasmine-ajax', 'jasmine']
+    frameworks: ['jasmine-ajax', 'jasmine'],
+    plugins: [karma-jasmine-ajax]
   });
 }
 ```


### PR DESCRIPTION
if not listed in plugins the user will get the error:

Warning: No provider for "framework:jasmine-ajax"!