### PR TITLE
Change karma peer dependency to include versions above 0.12

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "jasmine-ajax": "^3.0.0"
   },
   "peerDependencies": {
-    "karma": "~0.12.0"
+    "karma": ">=0.12.0"
   },
   "license": "MIT",
   "bugs": {


### PR DESCRIPTION
This prevents a warning about an unmet peer dependency when using Karma 0.13 or greater (which is now possible, with [the release of 0.13.0](https://github.com/karma-runner/karma/releases/tag/v0.13.0)).