### PR TITLE
Not need it

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,8 +15,7 @@ Add `jasmine-ajax` to the `frameworks` key in your Karma configuration, before `
 ```js
 module.exports = function(config) {
   config.set({
-    frameworks: ['jasmine-ajax', 'jasmine'],
-    plugins: [karma-jasmine-ajax]
+    frameworks: ['jasmine-ajax', 'jasmine']
   });
 }
 ```


### PR DESCRIPTION
Hey.

First of all, just `plugins: [karma-jasmine-ajax]` will throw the error, so, you need `plugins: ['karma-jasmine-ajax']`
Second thing - this is unnecessary. From karma documentation: 

```
By default, Karma loads all NPM modules that are siblinks to it and their name matches karma-*.
```
