### PR TITLE
Removed unnecessary line from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,8 +15,7 @@ Add `jasmine-ajax` to the `frameworks` key in your Karma configuration, before `
 ```js
 module.exports = function(config) {
   config.set({
-    frameworks: ['jasmine-ajax', 'jasmine'],
-    plugins: [karma-jasmine-ajax]
+    frameworks: ['jasmine-ajax', 'jasmine']
   });
 }
 ```


### PR DESCRIPTION
The line removed was not necessary, and as is, throws errors with the current version of Karma (1.1.0).