### PR TITLE
Update the readme to include the plugins configuration.

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,8 @@ Add `jasmine-ajax` to the `frameworks` key in your Karma configuration, before `
 ```js
 module.exports = function(config) {
   config.set({
-    frameworks: ['jasmine-ajax', 'jasmine']
+    frameworks: ['jasmine-ajax', 'jasmine'],
+    plugins: ['karma-jasmine', 'karma-jasmine-ajax']
   });
 }
 ```


### PR DESCRIPTION
- The following error is experienced when using Karma 3.0.0 if the plugins are not configured.

> ERROR [karma]: Error: No provider for "framework:jasmine-ajax"! (Resolving: framework:jasmine-ajax)

- Update the readme to reflect this requirement